### PR TITLE
storage may fail, it should not stop the web service

### DIFF
--- a/src/flask_track_usage/__init__.py
+++ b/src/flask_track_usage/__init__.py
@@ -199,7 +199,10 @@ class TrackUsage(object):
             data['ip_info'] = ip_info
 
         for storage in self._storages:
-            storage(data)
+            try:
+                storage(data)
+            except:
+                pass
         return response
 
     def exclude(self, view):


### PR DESCRIPTION
Storage action definitely will fail, but it should not be the show stopper!

In one of our experiment, we use mysql server as the storage backend.  After a day sitting idle, mysql server closed the connection, and then we had SQL 2006 "has gone away" error.  It brought down the flask service.

Adding exception checks should at least enable the web service to continue.